### PR TITLE
outsourced gas price oracle

### DIFF
--- a/contracts/gelato_core/GelatoCore.sol
+++ b/contracts/gelato_core/GelatoCore.sol
@@ -154,7 +154,7 @@ contract GelatoCore is IGelatoCore, GelatoExecutors {
         require(startGas > internalGasRequirement, "GelatoCore.exec: Insufficient gas sent");
 
         // memcopy of gelatoGasPrice and gelatoMaxGas, to avoid multiple storage reads
-        uint256 _gelatoGasPrice = gelatoGasPrice;
+        uint256 _gelatoGasPrice = gelatoGasPrice();
         uint256 _gelatoMaxGas = gelatoMaxGas;
 
         // CHECKS

--- a/contracts/gelato_core/GelatoOracle.sol
+++ b/contracts/gelato_core/GelatoOracle.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.6.4;
+
+import "../external/Ownable.sol";
+import "./interfaces/IGelatoOracle.sol";
+
+contract GelatoOracle is IGelatoOracle, Ownable {
+
+    address public override oracleAdmin;
+    address public override gelatoCore;
+    uint256 private gelatoGasPrice;
+
+    event LogSetGelatoGasPrice(uint256 indexed gelatoGasPrice, uint256 indexed _newGasPrice);
+    event LogSetNewOracleAdmin(address indexed newOracleAdmin);
+
+    constructor(uint256 _gelatoGasPrice, address _gelatoCore) public {
+        oracleAdmin = msg.sender;
+        gelatoGasPrice = _gelatoGasPrice;
+        gelatoCore = _gelatoCore;
+    }
+
+    function setGelatoGasPrice(uint256 _newGasPrice) external override  {
+        require(msg.sender == oracleAdmin, "Only oracleAdmin can set gelatoGasPrice");
+        require(_newGasPrice != 0, "gelatoGasPrice cannot be zero");
+        emit LogSetGelatoGasPrice(gelatoGasPrice, _newGasPrice);
+        gelatoGasPrice = _newGasPrice;
+    }
+
+    function getGasPrice() view external override returns(uint256) {
+        // emit LogSetGelatoGasPrice(gelatoGasPrice, _newGasPrice);
+        require(msg.sender == gelatoCore, "Only gelatoCore can read oracle");
+        return gelatoGasPrice;
+    }
+
+    function setOracleAdmin(address _newOracleAdmin) external onlyOwner override  {
+        require(_newOracleAdmin != address(0), "New Oracle admin cannot be address(0)");
+        emit LogSetNewOracleAdmin(_newOracleAdmin);
+        oracleAdmin = _newOracleAdmin;
+    }
+
+}

--- a/contracts/gelato_core/GelatoSysAdmin.sol
+++ b/contracts/gelato_core/GelatoSysAdmin.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.4;
 
 import "./interfaces/IGelatoSysAdmin.sol";
+import "./interfaces/IGelatoOracle.sol";
 import "../external/Ownable.sol";
 import "../external/Address.sol";
 import "../external/SafeMath.sol";
@@ -11,7 +12,8 @@ abstract contract GelatoSysAdmin is IGelatoSysAdmin, Ownable {
     using Address for address payable;
     using SafeMath for uint256;
 
-    uint256 public override gelatoGasPrice = 9000000000;  // 9 gwei initial
+    // uint256 public override gelatoGasPrice = 9000000000;  // 9 gwei initial
+    IGelatoOracle public override gelatoOracle;
     uint256 public override gelatoMaxGas = 7000000;  // 7 mio initial
     uint256 public override internalGasRequirement = 500000;
     uint256 public override minProviderStake = 0.1 ether;  // production: 1 ETH
@@ -24,10 +26,8 @@ abstract contract GelatoSysAdmin is IGelatoSysAdmin, Ownable {
 
     // == The main functions of the Sys Admin (DAO) ==
     // exec-tx gasprice
-    function setGelatoGasPrice(uint256 _newGasPrice) external override onlyOwner {
-        emit LogSetGelatoGasPrice(gelatoGasPrice, _newGasPrice);
-        require(_newGasPrice != 0, "Cannot be zero");
-        gelatoGasPrice = _newGasPrice;
+    function gelatoGasPrice() internal view returns(uint256) {
+        return gelatoOracle.getGasPrice();
     }
 
     // exec-tx gas
@@ -82,6 +82,13 @@ abstract contract GelatoSysAdmin is IGelatoSysAdmin, Ownable {
         emit LogSetSysAdminSuccessShare(sysAdminSuccessShare, _percentage);
         if (_percentage == 0) delete sysAdminSuccessShare;
         else sysAdminSuccessShare = _percentage;
+    }
+
+    // Set GelatoOracle
+    function setGelatoOracle(address _newOracle) external override onlyOwner {
+        require(_newOracle == address(0), "New oracle cannot be address(0)");
+        emit LogSetNewGelatoOracle(_newOracle);
+        gelatoOracle = IGelatoOracle(_newOracle);
     }
 
     function withdrawSysAdminFunds(uint256 _amount)

--- a/contracts/gelato_core/interfaces/IGelatoOracle.sol
+++ b/contracts/gelato_core/interfaces/IGelatoOracle.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.6.4;
+
+interface IGelatoOracle {
+
+    event LogSetGelatoGasPrice(uint256 indexed gelatoGasPrice, uint256 indexed _newGasPrice);
+    event LogSetNewOracleAdmin(address indexed newOracleAdmin);
+
+    function oracleAdmin() external returns(address);
+
+    function gelatoCore() external returns(address);
+
+    function setGelatoGasPrice(uint256 _newGasPrice) external;
+
+    function getGasPrice() external view returns(uint256);
+
+    function setOracleAdmin(address _newOracleAdmin) external;
+}

--- a/contracts/gelato_core/interfaces/IGelatoSysAdmin.sol
+++ b/contracts/gelato_core/interfaces/IGelatoSysAdmin.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.6.4;
 
+import "./IGelatoOracle.sol";
+
 interface IGelatoSysAdmin {
     // Events
     event LogSetGelatoGasPrice(uint256 oldGasPrice, uint256 newGasPrice);
@@ -15,10 +17,11 @@ interface IGelatoSysAdmin {
     event LogSetExecutorSuccessShare(uint256 oldShare, uint256 newShare);
     event LogSetSysAdminSuccessShare(uint256 oldFeeFactor, uint256 newFeeFactor);
 
+    event LogSetNewGelatoOracle(address newGelatoOracle);
+
     event LogWithdrawOracleFunds(uint256 oldBalance, uint256 newBalance);
 
     // State Writing
-    function setGelatoGasPrice(uint256 _newGasPrice) external;
     function setGelatoMaxGas(uint256 _newMaxGas) external;
     function setInternalGasRequirement(uint256 _newRequirement) external;
 
@@ -31,10 +34,12 @@ interface IGelatoSysAdmin {
     function setExecutorSuccessShare(uint256 _percentage) external;
     function setSysAdminSuccessShare(uint256 _percentage) external;
 
+    function setGelatoOracle(address _newOracle) external;
+
     function withdrawSysAdminFunds(uint256 _amount) external returns(uint256);
 
     // State Reading
-    function gelatoGasPrice() external view returns(uint256);
+    function gelatoOracle() external view returns(IGelatoOracle);
     function gelatoMaxGas() external view returns(uint256);
     function internalGasRequirement() external view returns(uint256);
 


### PR DESCRIPTION
- outsourced gas price oracle to external contract
- SysAdmin now queries price from external contract
- This contract address will be whitelisted by SysAdmin
- On this oracle contract, gelatoCore can read the gas price
- gelatoGasPrice getter is now internal. Only gelatoCore can query the gas price